### PR TITLE
Assign a default weight of 16 for streams.

### DIFF
--- a/src/h2priograph/h2priograph.go
+++ b/src/h2priograph/h2priograph.go
@@ -119,6 +119,7 @@ func main() {
 				if strings.Contains(line, "HTTP2_SESSION_RECV_PUSH_PROMISE") {
 					state = IN_PUSH_PROMISE
 					s = &Stream{}
+					s.priority = 16 /* streams are assigned a default weight of 16 */
 					s.is_push = true
 				}
 			}


### PR DESCRIPTION
This is not ideal, because Chrome 52 and 55 don't report weights in the
same way, 52 outputs an internal priority (0, 1, 3) whereas 55 reports
the H2 weights sent on the wire, so 16 really only applies to v55.
